### PR TITLE
Fixes and Enhancements for Modelio Docker Setup on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore IntelliJ IDEA project files and Visual Studio Code project files
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM debian:bullseye-slim
 #LABEL maintainer="gerald.hameau@gmail.com"
 LABEL maintainer="olivier.berger@telecom-sudparis.eu"
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ THIS SECTION WASN'T TESTED AND SHOULD BE CHECKED. PULL REQUESTS WELCOME
     ```
 6. build (optional, to specify architecture for M1 (apple silicon) macOS.)
     ```sh
-    docker build --platform linux/amd64 --tag olberger:docker-modelio:5.1 .
+    docker build --platform linux/amd64 --tag olberger/docker-modelio:5.1 .
     ```
 7. enable the `run.sh` script to be run
     ```sh

--- a/run.sh
+++ b/run.sh
@@ -7,4 +7,10 @@ xhost +$(hostname)
 
 #docker run -ti --rm -e DISPLAY=host.docker.internal:0 -v $HOME/.modelio:/home/modelio/.modelio:z -v $HOME/modelio:/home/modelio/modelio:z --net=host --ipc=host olberger/docker-modelio:5.1 bash
 #docker run -ti --rm -e DISPLAY=$DISPLAY -v $HOME/.modelio:/home/modelio/.modelio:z -v $HOME/modelio:/home/modelio/modelio:z --net=host --ipc=host olberger/docker-modelio:5.1 bash
-docker run -ti --rm --cpus 2.0 -e DISPLAY=host.docker.internal:0 -v $HOME/.modelio:/home/modelio/.modelio:z -v $HOME/modelio:/home/modelio/modelio:z --net=host --ipc=host olberger/docker-modelio:5.1 bash
+
+# Get the IP address of the host
+ip=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
+# Allow the host to connect to the X server
+xhost + $ip
+
+docker run -ti --rm --cpus 2.0 -e DISPLAY=$ip:0 -v $HOME/.modelio:/home/modelio/.modelio:z -v $HOME/modelio:/home/modelio/modelio:z --net=host --ipc=host olberger/docker-modelio:5.1 bash


### PR DESCRIPTION
### Fixes and Enhancements for Modelio Docker Setup on macOS

This PR includes several key fixes and improvements for running **Modelio** in a Docker container on macOS:

- **Fix X11 Authorization Issue**: Corrected the X11 authorization issue that was preventing Modelio from launching on macOS. The application can now successfully connect to the display server and run as expected.
  
- **Update Image Name in README**: Fixed the Docker image name reference in the README to ensure it matches the actual image used.

- **Resolve Warning for ENV Variables**

- **Add `.gitignore` for IDE Files**